### PR TITLE
Updated the shebang to the proper interpreter

### DIFF
--- a/src/test_api_response.py
+++ b/src/test_api_response.py
@@ -1,4 +1,5 @@
-#!/usr/env/python3
+#!/usr/bin/env python3
+
 """
 Test script for the basic API tests.
 Test design requirements:


### PR DESCRIPTION
The original line was a placeholder that never got replaced. New shebang
points `usr/bin/env python3`